### PR TITLE
implement KaitaiStruct as context manager

### DIFF
--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -8,17 +8,26 @@ except ImportError:
 
 
 class KaitaiStruct:
-    def __init__(self, _io):
-        self._io = _io
+    def __init__(self, stream):
+        self._io = stream
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close()
 
     @classmethod
     def from_file(cls, filename):
         return cls(KaitaiStream(open(filename, 'rb')))
 
+    def close(self):
+        self._io.close()
+
 
 class KaitaiStream:
-    def __init__(self, _io):
-        self._io = _io
+    def __init__(self, io):
+        self._io = io
 
     def close(self):
         self._io.close()


### PR DESCRIPTION
Followup to #6. KaitaiStruct now implements context manager interface, so you can use `with` keyword like with any other resource. Examples of context manager usage with automatically closed resource:

```python
>>> with KaitaiStruct.from_file(filename) as ks:
...     print ks._io._io.closed
... 
False
>>> ks._io._io.closed
True
```

```python
>>> myio = KaitaiStream(open(filename))
>>> myio._io.closed
False
>>> with KaitaiStruct(myio) as ks:
...     print ks._io._io.closed
... 
False
>>> ks._io._io.closed
True
```

This is generally accepted way to deal with resources that need to be closed in Python. However, you can create instance of KaitaiStream manually, but then you have to remember to close the resource.

```python
>>> ks = KaitaiStruct.from_file('setup.py')
>>> ks._io._io.closed
False
>>> ks.close()
>>> ks._io._io.closed
True
```
