### PR TITLE
Fix exception text and Python 2 compatibility improvements

### DIFF
--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -189,7 +189,7 @@ class KaitaiStream(object):
         r = self._io.read(n)
         if len(r) < n:
             raise EOFError(
-                "requested %d bytes, but got only %d bytes", n, len(r)
+                "requested %d bytes, but got only %d bytes" % (n, len(r))
             )
         return r
 
@@ -223,7 +223,7 @@ class KaitaiStream(object):
                 if eos_error:
                     raise Exception(
                         "End of stream reached, but no terminator %d found" %
-                        (term)
+                        (term,)
                     )
                 else:
                     return r.decode(encoding)
@@ -271,7 +271,7 @@ class KaitaiStream(object):
         if group_size != 1:
             raise Exception(
                 "unable to rotate group of %d bytes yet" %
-                (group_size)
+                (group_size,)
             )
 
         mask = group_size * 8 - 1

--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -11,7 +11,7 @@ except ImportError:
 PY2 = sys.version_info[0] == 2
 
 
-class KaitaiStruct:
+class KaitaiStruct(object):
     def __init__(self, stream):
         self._io = stream
 
@@ -35,7 +35,7 @@ class KaitaiStruct:
         self._io.close()
 
 
-class KaitaiStream:
+class KaitaiStream(object):
     def __init__(self, io):
         self._io = io
 


### PR DESCRIPTION
The behavior of `class A` (without any explicit inheritance) changed between Python 2 and 3 from creating an old-style class to creating a new-style one. The first commit addresses this issue by explicitly inheriting `object`, always creating a new-style class. While the old behavior works, it makes it hard to write code that uses the classes (e.g. inherits them) that is compatible to Py 2 and 3 as well.

The second commit fixes the exception text formatting and changes the redundant parentheses into tuples (I suppose you probably wanted tuples and forgot the `,`, resulting in the parentheses having no effect).