### PR TITLE
More helper methods - `from_bytes` and `from_io`

### DIFF
--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -40,6 +40,14 @@ class KaitaiStruct(object):
             f.close()
             raise
 
+    @classmethod
+    def from_bytes(cls, buf):
+        return cls(KaitaiStream(BytesIO(buf)))
+
+    @classmethod
+    def from_io(cls, io):
+        return cls(KaitaiStream(io))
+
     def close(self):
         self._io.close()
 


### PR DESCRIPTION
This PR adds more helper methods to make generated classes from accessible without diving deep into intricacies of Kaitai Struct from the very beginning. Akin to `from_file`, these are to be used:

* `from_bytes` - to parse an object from a `bytes` type, i.e. raw byte array
* `from_io` - to parse an object from any instance of Python's [IO stream object](https://docs.python.org/3/library/io.html), which can be a in-memory stream, file, socket, etc

Just some tiny wrappers that make life easier.

Cc @koczkatamas @felixonmars @dgladkov @KOLANICH