### PR TITLE
cStringIO is ancient, modern python hides it

### DIFF
--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -1,12 +1,7 @@
 import itertools
 import sys
 from struct import unpack
-
-try:
-    import cStringIO
-    BytesIO = cStringIO.StringIO
-except ImportError:
-    from io import BytesIO  # noqa
+from io import BytesIO  # noqa
 
 PY2 = sys.version_info[0] == 2
 


### PR DESCRIPTION
cStringIO should not be imported, it was deprecated a long time ago. Python (since some modern version) hides that module and just exposes the BytesIO class. Its same speed on modern Python.