### PR TITLE
pypi manifesto, adds Construct to keywords for mutual promotion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    keywords='kaitai,struct,ksy,declarative,data structure,data format,file format,packet format,binary,parser,parsing,unpack,development',
+    keywords='kaitai,struct,construct,ksy,declarative,data structure,data format,file format,packet format,binary,parser,parsing,unpack,development',
     py_modules=["kaitaistruct"],
 )


### PR DESCRIPTION
Construct added Kaitai to PYPI keywords, for mutual promotion. I request you do the same?
https://github.com/construct/construct/commit/079ae860a995aa5107ae678411c38465e56335b0
