### PR TITLE
Remove unused import (struct.unpack)

### DIFF
--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -1,7 +1,6 @@
 import itertools
 import sys
 import struct
-from struct import unpack
 from io import BytesIO  # noqa
 
 PY2 = sys.version_info[0] == 2


### PR DESCRIPTION
Code was switched to using struct.Struct().unpack in 7fba4d2.