### PR TITLE
Fix setup.py to work with setuptools 41.4.0 and later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,3 @@
-import os
 from setuptools import setup
-from setuptools.config import read_configuration
 
-this_dir = os.path.dirname(__file__)
-cfg = read_configuration(os.path.join(this_dir, 'setup.cfg'))
-cfg["options"].update(cfg["metadata"])
-cfg = cfg["options"]
-
-setup(**cfg)
+setup()


### PR DESCRIPTION
Fixes #43 and fixes #45 and fixes #47.

This change is effectively also included in #39, but there hasn't been any progress on that PR recently. The setuptools compatibility issue has been reported multiple times recently (which makes sense - the current code is incompatible with many recent setuptools versions), so I think it makes sense to apply this fix separately from the larger PR #39.