### PR TITLE
Extend user-defined exception from Exception instead of BaseException

### DIFF
--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -409,7 +409,7 @@ class KaitaiStream(object):
             return value
 
 
-class KaitaiStructError(BaseException):
+class KaitaiStructError(Exception):
     """Common ancestor for all error originating from Kaitai Struct usage.
     Stores KSY source path, pointing to an element supposedly guilty of
     an error.


### PR DESCRIPTION
I've noticed that the KaitaiStructError extends BaseException instead of Exception. This is contrary to the python official documentation (https://docs.python.org/3/library/exceptions.html):

> programmers are encouraged to derive new exceptions from the Exception class or one of its subclasses, and not from BaseException.

> exception **BaseException**: The base class for all built-in exceptions. It is not meant to be directly inherited by user-defined classes (for that, use Exception).

And makes it not possible to catch a decoding exception when using the standard method: 

```python
try:
    g = Gif.from_bytes(message_bytes)
except Exception as e:
    print(e)
```

Is there a specific reason for extending from BaseException that I'm missing?

Thank you very much!
