### PR TITLE
Add more PyPI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Kaitai Struct: runtime library for Python
 
 [![PyPI](https://img.shields.io/pypi/v/kaitaistruct)](https://pypi.org/project/kaitaistruct/)
-![PyPI - Format](https://img.shields.io/pypi/format/kaitaistruct)
-![PyPI - Wheel](https://img.shields.io/pypi/wheel/kaitaistruct)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/kaitaistruct)
-![PyPI - Implementation](https://img.shields.io/pypi/implementation/kaitaistruct)
-![PyPI - Downloads](https://img.shields.io/pypi/dd/kaitaistruct)
+[![PyPI - Downloads](https://img.shields.io/pypi/dd/kaitaistruct)](https://pypistats.org/packages/kaitaistruct)
 
 This library implements Kaitai Struct API for Python.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Kaitai Struct: runtime library for Python
 
 [![PyPI](https://img.shields.io/pypi/v/kaitaistruct)](https://pypi.org/project/kaitaistruct/)
+![PyPI - Format](https://img.shields.io/pypi/format/kaitaistruct)
+![PyPI - Wheel](https://img.shields.io/pypi/wheel/kaitaistruct)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/kaitaistruct)
+![PyPI - Implementation](https://img.shields.io/pypi/implementation/kaitaistruct)
+![PyPI - Downloads](https://img.shields.io/pypi/dd/kaitaistruct)
 
 This library implements Kaitai Struct API for Python.
 


### PR DESCRIPTION
I've already added a badge showing the `kaitaistruct` package version at PyPI, check out the [readme](https://github.com/kaitai-io/kaitai_struct_python_runtime#readme):

![PyPI](https://img.shields.io/pypi/v/kaitaistruct)

But there are other badges at https://shields.io/ that show additional info that can be useful for users. I added all of them that I consider potentially reasonable or relevant for this project, and I'd like to hear from Python experts what information is not relevant.

Another thing I'd like to know is whether there are some pages at PyPI or other websites that the badges could link to when clicked. The point is to provide some proof or basis for the information that the badge claims - for example, when the badge claims

![PyPI - Downloads](https://img.shields.io/pypi/dd/kaitaistruct)

..., it would be nice to link to a PyPI page where one can look at a more detailed graph with the number of downloads over time. However, it seems that PyPI doesn't provide it - then isn't there some third-party service that does?

For example, in the JavaScript ecosystem, there is [npmtrends.com](https://www.npmtrends.com/kaitai-struct-compiler), which shows exactly this for `npm` packages (but it's not affiliated to [npmjs.com](https://www.npmjs.com/) authors or GitHub in any way - it's created [by a guy John Potter](https://github.com/johnmpotter/npm-trends)). You can even put more packages in the graph and compare which one is/was more popular over time - e.g. [kaitai-struct-compiler vs. jbinary](https://www.npmtrends.com/kaitai-struct-compiler-vs-jbinary).

If there's no specific for that measure, that's fine: it just won't be clickable. I'd like to avoid linking all badges to https://pypi.org/project/kaitaistruct/ when the information is not there - that gives the reader false hope that he can learn something more about the particular statement of the badge, but he'd be actually sent to a general `kaitaistruct` PyPI package homepage where he didn't want to go (if he did, he'd click the [![PyPI](https://img.shields.io/pypi/v/kaitaistruct)](https://pypi.org/project/kaitaistruct/)).

Cc @GreyCat, @dgelessus, @arekbulski, @cugu 