### PR TITLE
Add conditional dependency on importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ zip_safe = True
 include_package_data = True
 py_modules = kaitaistruct
 python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+# The ksc-generated parsers depend on this, so we add it as a dependency here.
+install_requires =
+    importlib-metadata;python_version<'3.8'
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
This prepares a switch in the Kaitai compiler to not depend on `pkg_resources` anymore, see #62.