### PR TITLE
Remove redundant wheel dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 38.6.0", "wheel >= 0.23.0"]
+requires = ["setuptools >= 38.6.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
     enum34; python_version < "3.4"
 setup_requires =
     setuptools >= 38.6.0
-    wheel >= 0.23.0
 
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend
automatically.  Listing it explicitly in the documentation was
a historical mistake and has been fixed since, see:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a