### PR TITLE
add support local implement for micro-python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,3 +9,8 @@ jobs:
       - uses: actions/checkout@v1
       - name: Python Style Checker
         uses: andymckay/pycodestyle-action@0.1.3
+
+      - name: Run Pytest
+        uses: fylein/python-pytest-github-action@v1
+        with:
+          args: pytest

--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -9,13 +9,19 @@ except ImportError:
     SEEK_END = 2
 
 
-def local_cycle(buf):
-    buf = list(buf)
-    if not buf:
-        return
-    while 1:
-        for b in buf:
-            yield b
+def local_cycle(p):
+    try:
+        len(p)
+    except TypeError:
+        # len() is not defined for this type. Assume it is
+        # a finite iterable so we must cache the elements.
+        cache = []
+        for i in p:
+            yield i
+            cache.append(i)
+        p = cache
+    while p:
+        yield from p
 
 
 try:

--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -1,7 +1,28 @@
-import itertools
 import sys
 import struct
-from io import open, BytesIO, SEEK_CUR, SEEK_END  # noqa
+from io import open, BytesIO # noqa
+
+try:
+    from io import SEEK_CUR, SEEK_END
+except ImportError:
+    SEEK_CUR = 1
+    SEEK_END = 2
+
+
+def local_cycle(buf):
+    buf = list(buf)
+    if not buf:
+        return
+    while 1:
+        for b in buf:
+            yield b
+
+
+try:
+    from itertools import cycle 
+except ImportError:
+    cycle = local_cycle
+    
 
 PY2 = sys.version_info[0] == 2
 

--- a/kaitaistruct.py
+++ b/kaitaistruct.py
@@ -411,9 +411,9 @@ class KaitaiStream(object):
     @staticmethod
     def process_xor_many(data, key):
         if PY2:
-            return bytes(bytearray(a ^ b for a, b in zip(bytearray(data), itertools.cycle(bytearray(key)))))
+            return bytes(bytearray(a ^ b for a, b in zip(bytearray(data), cycle(bytearray(key)))))
 
-        return bytes(a ^ b for a, b in zip(data, itertools.cycle(key)))
+        return bytes(a ^ b for a, b in zip(data, cycle(key)))
 
     @staticmethod
     def process_rotate_left(data, amount, group_size):

--- a/test_with_micro_python.py
+++ b/test_with_micro_python.py
@@ -1,0 +1,12 @@
+
+
+def test_cycle():
+    from kaitaistruct import local_cycle
+    data = dict(zip([1, 2, 3, 4, 5], local_cycle([1, 2, 3])))
+    assert len(data) == 5
+    assert data[5] == 2
+
+    i = 0
+    for x in local_cycle([]):
+        i += 1
+    assert i == 0


### PR DESCRIPTION
I was using kaitaistruct to process some binary data with a micro-python low level device.
it does not have the module `itertools`, since this package only use `cycle` for make a loop iter on the bytearray

so i add an `local_cycle` implement for the env without itertools 

and i add a test for it, it was run with a pytest
